### PR TITLE
feat: Add API endpoint for renaming files

### DIFF
--- a/database/renameDoc.go
+++ b/database/renameDoc.go
@@ -1,0 +1,8 @@
+package database
+
+import "github.com/go-fast-cdn/models"
+
+func RenameDoc(oldFileName, newFileName string) error {
+	doc := models.Doc{}
+	return DB.Model(&doc).Where("file_name = ?", oldFileName).Update("file_name", newFileName).Error
+}

--- a/database/renameImage.go
+++ b/database/renameImage.go
@@ -1,0 +1,8 @@
+package database
+
+import "github.com/go-fast-cdn/models"
+
+func RenameImage(oldFileName, newFileName string) error {
+	image := models.Image{}
+	return DB.Model(&image).Where("file_name = ?", oldFileName).Update("file_name", newFileName).Error
+}

--- a/router/api.go
+++ b/router/api.go
@@ -31,4 +31,10 @@ func AddApiRoutes(r *gin.Engine) {
 		upload.POST("/image", iHandlers.HandleImageUpload)
 		upload.POST("/doc", dHandlers.HandleDocsUpload)
 	}
+
+	rename := cdn.Group("/rename")
+	{
+		rename.PUT("/image", iHandlers.HandleImageRename)
+		rename.PUT("/doc", dHandlers.HandleDocsRename)
+	}
 }

--- a/util/handlers/docs/handleDocsRename.go
+++ b/util/handlers/docs/handleDocsRename.go
@@ -1,0 +1,26 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-fast-cdn/database"
+)
+
+func HandleDocsRename(c *gin.Context) {
+	oldName := c.PostForm("filename")
+	newName := c.PostForm("newname")
+
+	if oldName == "" || newName == "" {
+		c.String(http.StatusBadRequest, "Invalid request")
+		return
+	}
+
+	err := database.RenameDoc(oldName, newName)
+	if err != nil {
+		c.String(http.StatusInternalServerError, "Failed to rename file: %s", err.Error())
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": "File renamed successfully"})
+}

--- a/util/handlers/image/handleImageRename.go
+++ b/util/handlers/image/handleImageRename.go
@@ -1,0 +1,26 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-fast-cdn/database"
+)
+
+func HandleImageRename(c *gin.Context) {
+	oldName := c.PostForm("filename")
+	newName := c.PostForm("newname")
+
+	if oldName == "" || newName == "" {
+		c.String(http.StatusBadRequest, "Invalid request")
+		return
+	}
+
+	err := database.RenameImage(oldName, newName)
+	if err != nil {
+		c.String(http.StatusInternalServerError, "Failed to rename file: %s", err.Error())
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": "File renamed successfully"})
+}


### PR DESCRIPTION
Renames are done with simple update statesments using GORM.

I follow the same router grouping pattern as you have done previously for upload and suggest we do the same for delete @ankit-pn .  Unless you would like to suggest a different structure, I'm happy to adjust.

Closes #18 