### PR TITLE
added delete apis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build_ui:
 	pnpm --dir ./ui build
 
 build_bin:
-	GOARCH=amd64 GOOS=darwin go build -o bin/${BINARY_NAME}-darwin 
+	GOARCH=amd64 GOOS=darwin CGO_ENABLED=1 go build -o bin/${BINARY_NAME}-darwin 
 	CC="x86_64-linux-musl-gcc" GOARCH=amd64 GOOS=linux go build -o bin/${BINARY_NAME}-linux
 	CC="x86_64-w64-mingw32-gcc" GOARCH=amd64 GOOS=windows go build -o bin/${BINARY_NAME}-windows
 

--- a/database/doc.go
+++ b/database/doc.go
@@ -19,3 +19,17 @@ func AddDoc(fileName string, fileHashBuffer []byte) (string, bool) {
 		return entries[0].FileName, true
 	}
 }
+
+
+func DeleteDoc(fileName string) (string, bool) {
+	var doc models.Doc
+
+	result := DB.Where("file_name = ?", fileName).First(&doc)
+
+	if result.Error == nil {
+		DB.Delete(&doc)
+		return fileName, true
+	} else {
+		return "", false
+	}
+}

--- a/database/image.go
+++ b/database/image.go
@@ -19,3 +19,16 @@ func AddImage(fileName string, fileHashBuffer []byte) (string, bool) {
 		return entries[0].FileName, true
 	}
 }
+
+func DeleteImage(fileName string) (string, bool) {
+	var image models.Image
+
+	result := DB.Where("file_name = ?", fileName).First(&image)
+
+	if result.Error == nil {
+		DB.Delete(&image)
+		return fileName, true
+	} else {
+		return "", false
+	}
+}

--- a/router/api.go
+++ b/router/api.go
@@ -29,6 +29,12 @@ func AddApiRoutes(r *gin.Engine) {
 	upload := cdn.Group("/upload")
 	{
 		upload.POST("/image", iHandlers.HandleImageUpload)
-		upload.POST("/doc", dHandlers.HandleDocsUpload)
+		upload.POST("/doc", dHandlers.HandleDocUpload)
+	}
+
+	delete := cdn.Group("/delete")
+	{
+		delete.DELETE("/image/:filename", iHandlers.HandleImageDelete)
+		delete.DELETE("/doc/:filename", dHandlers.HandleDocDelete)
 	}
 }

--- a/util/handlers/docs/handleDocDelete.go
+++ b/util/handlers/docs/handleDocDelete.go
@@ -1,0 +1,36 @@
+package handlers
+
+import (
+	"net/http"
+
+	"fmt"
+	"github.com/gin-gonic/gin"
+	"github.com/go-fast-cdn/database"
+	"github.com/go-fast-cdn/util"
+	"os"
+)
+
+func HandleDocDelete(c *gin.Context) {
+	fileName := c.Param("filename")
+	if fileName == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Doc name is required",
+		})
+		return
+	}
+	deletedFileName, success := database.DeleteDoc(fileName)
+	filePath := fmt.Sprintf("%v/uploads/docs/%v", util.ExPath, deletedFileName)
+	err := os.Remove(filePath)
+	if success && err == nil {
+		c.JSON(http.StatusOK, gin.H{
+			"message":  "Document deleted successfuly",
+			"fileName": deletedFileName,
+		})
+	} else {
+		fmt.Println(success)
+		fmt.Println(err)
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": "Document not found",
+		})
+	}
+}

--- a/util/handlers/docs/handleDocUpload.go
+++ b/util/handlers/docs/handleDocUpload.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-fast-cdn/util"
 )
 
-func HandleDocsUpload(c *gin.Context) {
+func HandleDocUpload(c *gin.Context) {
 	fileHeader, err := c.FormFile("doc")
 	newName := c.PostForm("filename")
 

--- a/util/handlers/image/handleImageDelete.go
+++ b/util/handlers/image/handleImageDelete.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"fmt"
+	"github.com/gin-gonic/gin"
+	"github.com/go-fast-cdn/database"
+	"github.com/go-fast-cdn/util"
+	"net/http"
+	"os"
+)
+
+func HandleImageDelete(c *gin.Context) {
+	fileName := c.Param("filename")
+	if fileName == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Doc name is required",
+		})
+		return
+	}
+	deletedFileName, success := database.DeleteImage(fileName)
+	filePath := fmt.Sprintf("%v/uploads/images/%v", util.ExPath, deletedFileName)
+	err := os.Remove(filePath)
+	if success && err == nil {
+		c.JSON(http.StatusOK, gin.H{
+			"message":  "Image deleted successfuly",
+			"fileName": deletedFileName,
+		})
+	} else {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": "Image not found",
+		})
+	}
+}


### PR DESCRIPTION
restructured the database package - removed addDoc.go and addImage.go and included doc.go and image.go, these two file should contain logic of every database operation.

renamed handleDocsUpload.go to handleDocUpload.go - since we are dealing with 1 file at a time, it is better to keep doc instead of docs

modified - api.go to include delete endpoint

added HandleImageDelete and HandleDocDelete Method to deal with deletion