### PR TITLE
[Security] New filename go through FilterFilename function while renaming

### DIFF
--- a/handlers/image/handleImageRename.go
+++ b/handlers/image/handleImageRename.go
@@ -19,18 +19,25 @@ func HandleImageRename(c *gin.Context) {
 		return
 	}
 
+	filteredNewName, err := util.FilterFilename(newName)
+
+	if err != nil {
+		c.String(http.StatusBadRequest, err.Error())
+		return
+	}
+
 	prefix := filepath.Join(util.ExPath, "uploads", "images")
 
-	err := os.Rename(
+	err = os.Rename(
 		filepath.Join(prefix, oldName),
-		filepath.Join(prefix, newName),
+		filepath.Join(prefix, filteredNewName),
 	)
 	if err != nil {
 		c.String(http.StatusInternalServerError, "Failed to rename file: %s", err.Error())
 		return
 	}
 
-	err = database.RenameImage(oldName, newName)
+	err = database.RenameImage(oldName, filteredNewName)
 	if err != nil {
 		c.String(http.StatusInternalServerError, "Failed to rename file: %s", err.Error())
 		return

--- a/util/filterFilename_test.go
+++ b/util/filterFilename_test.go
@@ -1,0 +1,31 @@
+package util
+
+import "testing"
+
+func TestFilterFilename(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		{"file.txt", "file.txt", false},
+		{"file/with/slashes.txt", "filewithslashes.txt", false},
+		{"file\\with\\backslashes.txt", "filewithbackslashes.txt", false},
+		{"file/with/more/than/one.period.txt", "file/with/more/than/one.period.txt", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result, err := FilterFilename(tc.input)
+
+			if (err != nil) != tc.wantErr {
+				t.Errorf("FilterFilename(%s) error = %v, wantErr %v", tc.input, err, tc.wantErr)
+				return
+			}
+
+			if result != tc.expected {
+				t.Errorf("FilterFilename(%s) = %v, want %v", tc.input, result, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
New name provided by user goes through already implemented FilterFilename function in HandleImageRename.

I've also added unit tests for FilterFilename, which was mentioned in [#49](https://github.com/kevinanielsen/go-fast-cdn/issues/49)