### PR TITLE
feat: add endpoint for getting data about a given document

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,9 @@ require (
 	github.com/gin-gonic/contrib v0.0.0-20221130124618-7e01895a63f2
 	github.com/gin-gonic/gin v1.9.1
 	github.com/glebarez/sqlite v1.10.0
+	github.com/google/uuid v1.5.0
 	github.com/joho/godotenv v1.5.1
+	github.com/stretchr/testify v1.8.4
 	gorm.io/gorm v1.25.5
 )
 
@@ -15,6 +17,7 @@ require (
 	github.com/bytedance/sonic v1.10.2 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
@@ -24,7 +27,6 @@ require (
 	github.com/go-playground/validator/v10 v10.16.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
-	github.com/google/uuid v1.5.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -35,6 +37,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect

--- a/handlers/docs/handleDocMetadata.go
+++ b/handlers/docs/handleDocMetadata.go
@@ -2,9 +2,10 @@ package handlers
 
 import (
 	"errors"
-	"fmt"
+	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 
 	"github.com/kevinanielsen/go-fast-cdn/util"
 
@@ -20,7 +21,7 @@ func HandleDocMetadata(c *gin.Context) {
 		return
 	}
 
-	filePath := fmt.Sprintf("%v/uploads/docs/%v", util.ExPath, fileName)
+	filePath := filepath.Join(util.ExPath, "uploads", "docs", fileName)
 	stat, err := os.Stat(filePath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -28,6 +29,7 @@ func HandleDocMetadata(c *gin.Context) {
 				"error": "Doc does not exist",
 			})
 		} else {
+			log.Printf("Failed to get document %s: %s\n", fileName, err.Error())
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": "Internal error",
 			})

--- a/handlers/docs/handleDocMetadata.go
+++ b/handlers/docs/handleDocMetadata.go
@@ -1,0 +1,43 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/kevinanielsen/go-fast-cdn/util"
+
+	"github.com/gin-gonic/gin"
+)
+
+func HandleDocMetadata(c *gin.Context) {
+	fileName := c.Param("filename")
+	if fileName == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Doc name is required",
+		})
+		return
+	}
+
+	filePath := fmt.Sprintf("%v/uploads/docs/%v", util.ExPath, fileName)
+	stat, err := os.Stat(filePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			c.JSON(http.StatusNotFound, gin.H{
+				"error": "Doc does not exist",
+			})
+		} else {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "Internal error",
+			})
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"filename":     fileName,
+		"download_url": c.Request.Host + "/api/cdn/download/docs/" + fileName,
+		"file_size":    stat.Size(),
+	})
+}

--- a/handlers/docs/handleDocMetadata_test.go
+++ b/handlers/docs/handleDocMetadata_test.go
@@ -1,0 +1,92 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kevinanielsen/go-fast-cdn/util"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleDocMetadata_NoError(t *testing.T) {
+	// Arrange
+	testFileName := uuid.NewString()
+	testFileDir := filepath.Join(util.ExPath, "uploads", "docs")
+	defer os.RemoveAll(filepath.Join(util.ExPath, "uploads"))
+	err := os.MkdirAll(testFileDir, 0766)
+	require.NoError(t, err)
+	testFilePath := filepath.Join(testFileDir, testFileName)
+	testFileContents := uuid.NewString()
+	err = os.WriteFile(testFilePath, []byte(testFileContents), 0666)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/test", nil)
+	c.Params = []gin.Param{{
+		Key:   "filename",
+		Value: testFileName,
+	}}
+
+	// Act
+	HandleDocMetadata(c)
+
+	// Assert
+	require.Equal(t, http.StatusOK, w.Result().StatusCode)
+	result := map[string]interface{}{}
+	err = json.NewDecoder(w.Body).Decode(&result)
+	require.NoError(t, err)
+	require.Contains(t, result, "filename")
+	require.Equal(t, result["filename"], testFileName)
+	require.Contains(t, result, "download_url")
+	require.NotEmpty(t, result["download_url"])
+	require.Contains(t, result, "file_size")
+	require.Equal(t, float64(len(testFileContents)), result["file_size"])
+}
+
+func TestHandleDocMetadata_NotFound(t *testing.T) {
+	// Arrange
+	testFileName := uuid.NewString()
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/test", nil)
+	c.Params = []gin.Param{{
+		Key:   "filename",
+		Value: testFileName,
+	}}
+
+	// Act
+	HandleDocMetadata(c)
+
+	// Assert
+	require.Equal(t, http.StatusNotFound, w.Result().StatusCode)
+	result := map[string]interface{}{}
+	err := json.NewDecoder(w.Body).Decode(&result)
+	require.NoError(t, err)
+	require.Contains(t, result, "error")
+	require.Equal(t, result["error"], "Doc does not exist")
+}
+
+func TestHandleDocMetadata_NameNotProvided(t *testing.T) {
+	// Arrange
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/test", nil)
+
+	// Act
+	HandleDocMetadata(c)
+
+	// Assert
+	require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+	result := map[string]interface{}{}
+	err := json.NewDecoder(w.Body).Decode(&result)
+	require.NoError(t, err)
+	require.Contains(t, result, "error")
+	require.Equal(t, result["error"], "Doc name is required")
+}

--- a/router/api.go
+++ b/router/api.go
@@ -22,6 +22,7 @@ func AddApiRoutes(r *gin.Engine) {
 	{
 		cdn.GET("/size", handlers.GetSizeHandler)
 		cdn.GET("/doc/all", dHandlers.HandleAllDocs)
+		cdn.GET("/doc/:filename", dHandlers.HandleDocMetadata)
 		cdn.GET("/image/all", iHandlers.HandleAllImages)
 		cdn.POST("/drop/database", dbHandlers.HandleDropDB)
 		cdn.Static("/download/images", util.ExPath+"/uploads/images")

--- a/static/openapi.json
+++ b/static/openapi.json
@@ -61,6 +61,67 @@
         }
       }
     },
+    "/api/cdn/doc/{fileName}": {
+      "get": {
+        "description": "Retrieves metadata about the document",
+        "responses": {
+          "400": {
+            "description": "Document filename was not provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Document was not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unknown error while trying to retrieve the document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Metadata about the document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                    "properties": {
+                      "filename": { "type": "string" },
+                      "download_url":{ "type": "string" },
+                      "file_size": { "type": "number" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/cdn/image/all": {
       "get": {
         "summary": "Get all images",


### PR DESCRIPTION
Related to #75 

Adds endpoint at `/api/cdn/doc/:filename` that attempts to get relevant information for the requested document.

Example:
`GET http://localhost:8080/api/cdn/doc/resume.pdf`
returns
```json
{
  "download_url": "localhost:8080/api/cdn/download/docs/resume.pdf",
  "file_size": 68403,
  "filename": "resume.pdf"
}
```

Confirmed the `download_url` works by pasting it in a web browser

I have not yet written any documentation for this endpoint yet. Wanted to get initial feedback first.