### PR TITLE
[CI] Add make target and actions job to execute tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Run integration tests
+
+on:
+  # Runs when a push is made the main branch
+  push:
+    branches: [ "main" ]
+  # Runs when a PR is targeting the main branch
+  pull_request:
+    branches: [ "main" ]
+  # Manual activation
+  workflow_dispatch:
+
+jobs:
+  go_test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.21.3"
+      - name: Tidy modules
+        run: go mod tidy
+      - name: Run tests
+        run: go test -v -coverprofile coverage.csv ./...
+      - name: Create coverage report
+        run: go tool cover -html=coverage.csv -o coverage.html
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage.html
+          path: coverage.html

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,19 +13,42 @@ on:
 jobs:
   go_test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [ 18 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8.x
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "pnpm"
+          cache-dependency-path: ui/pnpm-lock.yaml
+
+      - name: Build UI Dashboard
+        run: pnpm --dir=./ui install && pnpm --dir=./ui build
+
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: ">=1.21.3"
+
       - name: Tidy modules
         run: go mod tidy
+
       - name: Run tests
         run: go test -v -coverprofile coverage.csv ./...
+
       - name: Create coverage report
         run: go tool cover -html=coverage.csv -o coverage.html
+
       - name: Upload coverage report
         uses: actions/upload-artifact@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,6 @@ clean:
 
 vet:
 	go vet
+
+test:
+	go test ./...

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ If you do not wish to use this, you can just rename `.example.env` to `.env` and
 
 1. Run `make prep`
 2. Run `make clean`
-3. Run `make build` <br>
+3. Run `make test`
+4. Run `make build`
 
-Your binary should now be built and you can run it with `bin/go-fast-cdn-linux` or `bin/go-fast-cdn-windows` or `bin/go-fast-cdn-darwin`
+Your binary should now be tested, built, and you can run it with `bin/go-fast-cdn-linux` or `bin/go-fast-cdn-windows` or `bin/go-fast-cdn-darwin`


### PR DESCRIPTION
Relates to #84 
- Adds make target to execute tests; `make test`
- Modified readme to mention the new make target
- Added github actions job to execute tests and upload a coverage report