### PR TITLE
fix: adding file name validation before adding file to database

### DIFF
--- a/src/handlers/docs/handleDocUpload.go
+++ b/src/handlers/docs/handleDocUpload.go
@@ -57,13 +57,14 @@ func HandleDocUpload(c *gin.Context) {
 	} else {
 		filename = newName + filepath.Ext(fileHeader.Filename)
 	}
-	savedFileName, alreadyExists := database.AddDoc(filename, fileHashBuffer[:])
 
 	filteredFilename, err := util.FilterFilename(filename)
 	if err != nil {
 		c.String(http.StatusBadRequest, err.Error())
 		return
 	}
+
+	savedFileName, alreadyExists := database.AddDoc(filename, fileHashBuffer[:])
 
 	if !alreadyExists {
 		err = c.SaveUploadedFile(fileHeader, util.ExPath+"/uploads/docs/"+filteredFilename)


### PR DESCRIPTION
This pull request fixes an error that even if `util.FilterFilename` return an error, the application writes it to the database

Follow the flow to reproduce the error

1. upload file with name `Arquitetura Limpa - O Guia do Artesão para Estrutura e Design de Software (Robert C. Martin) (Z-Library).pdf` guive an error
![image](https://github.com/kevinanielsen/go-fast-cdn/assets/87894998/bd0f8d38-c21a-4e1b-be63-7d246e876b21)

2. But even so, it still registers in the database
![image](https://github.com/kevinanielsen/go-fast-cdn/assets/87894998/127f689c-f8c4-4e1b-bef0-cc7b326d23cc)

3. If I try to delete it, an error occurs.
![image](https://github.com/kevinanielsen/go-fast-cdn/assets/87894998/a86260fb-8602-4e3b-af2f-07370cf37fcf)

4. However, even with the error, it still gets deleted from the database (requires refreshing the page).![image](https://github.com/kevinanielsen/go-fast-cdn/assets/87894998/414bd2b7-5a13-4838-8bba-42e8dc4aeb29)

With the current state of this pull request, the issue is resolved. However, we need to investigate why the util.FilterFilename function returned an error for the file name. If necessary, we may have to make modifications to the util.FilterFilename function. Additionally, we need to look into why step 3 returned an error when I clicked delete. Nonetheless, in step 4, after refreshing the page, the data was deleted from the database despite the error.