### PR TITLE
feat: support for more OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 BINARY_NAME=go-fast-cdn
+OS_NAME := $(shell uname -s | tr A-Z a-z)
 
 prep:
 	go mod tidy
@@ -16,7 +17,11 @@ build_bin:
 	CC="x86_64-w64-mingw32-gcc" GOARCH=amd64 GOOS=windows CGO_ENABLED=0 go build -o bin/${BINARY_NAME}-windows
 
 run: build
-	bin/${BINARY_NAME}-darwin
+ifeq ($(OS_NAME),)
+	bin/${BINARY_NAME}-windows
+else
+	bin/${BINARY_NAME}-${OS_NAME}
+endif
 
 clean: 
 	go clean


### PR DESCRIPTION
This modification introduces logic into the Makefile so that depending on the operating system (OS), the appropriate command is executed to launch the application.

:warning: It was tested on Linux, the expected output on MacOS is Darwin and the uname -s command does not exist on Windows so I left it in else