### PR TITLE
feat: add support for txt files

### DIFF
--- a/src/handlers/docs/handleDocUpload.go
+++ b/src/handlers/docs/handleDocUpload.go
@@ -35,8 +35,9 @@ func HandleDocUpload(c *gin.Context) {
 	fileType := http.DetectContentType(fileBuffer)
 
 	allowedMimeTypes := map[string]bool{
-		"text/plain":         true,
-		"application/msword": true,
+		"text/plain":                true,
+		"text/plain; charset=utf-8": true,
+		"application/msword":        true,
 		"application/vnd.openxmlformats-officedocument.wordprocessingml.document":   true,
 		"application/vnd.openxmlformats-officedocument.presentationml.presentation": true,
 		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":         true,


### PR DESCRIPTION
I noticed that when I tried to send a .txt file, it returned an error saying it wasn't supported, even though the map had the option for txt. The issue arose because my file had charset=utf-8, and since there was no corresponding entry in the map, it resulted in an error. I chose not to remove text/plain because there might be files that aren't in utf-8 format.