### PR TITLE
Add in specific ARCH to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 BINARY_NAME=go-fast-cdn
 OS_NAME := $(shell uname -s | tr A-Z a-z)
+ARCH := $(shell arch | tr A-Z a-z | sed 's/^aarch/arm/')
 
 prep:
 	go mod tidy
@@ -12,9 +13,9 @@ build_ui:
 	pnpm --dir ./ui build
 
 build_bin:
-	GOARCH=amd64 GOOS=darwin CGO_ENABLED=0 go build -o bin/${BINARY_NAME}-darwin 
-	CC="x86_64-linux-musl-gcc" GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -o bin/${BINARY_NAME}-linux
-	CC="x86_64-w64-mingw32-gcc" GOARCH=amd64 GOOS=windows CGO_ENABLED=0 go build -o bin/${BINARY_NAME}-windows
+	GOARCH=${ARCH} GOOS=darwin CGO_ENABLED=0 go build -o bin/${BINARY_NAME}-darwin 
+	CC="x86_64-linux-musl-gcc" GOARCH=${ARCH} GOOS=linux CGO_ENABLED=0 go build -o bin/${BINARY_NAME}-linux
+	CC="x86_64-w64-mingw32-gcc" GOARCH=${ARCH} GOOS=windows CGO_ENABLED=0 go build -o bin/${BINARY_NAME}-windows
 
 run: build
 ifeq ($(OS_NAME),)


### PR DESCRIPTION
Recently had issues with deploying this on my Raspberry Pi and realized that the `make build` creates binaries that are only `amd64`. I think that it would be best to create the binaries based on the OS executing `make build`, or if we have some additional parameter that determines the architecture to build.