### PR TITLE
feat(docker): Quickstart app with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Build the UI
+FROM node:18.17.0-bullseye-slim AS nodework
+WORKDIR /app
+COPY ui/ .
+RUN npm install
+RUN npm run build
+
+# Build the Go binary
+FROM golang:1.22 AS gowork
+WORKDIR /app
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+COPY . .
+COPY --from=nodework /app/build ui/build
+RUN go build -o /app/main .
+
+
+# Run the binary in a alpine container
+FROM ubuntu:22.04
+WORKDIR /app
+COPY --from=gowork /app/main .
+CMD [ "./main" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  server:
+    image: go-fast-cdn
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - uploads:/app/uploads
+      - db_data:/app/db_data
+    container_name: go-fast-cdn
+volumes:
+  db_data:
+  uploads:


### PR DESCRIPTION
This PR adds a Dockerfile and docker-compose.yml to containerize the application. The Dockerfile sets up multi-stage builds for the front-end and back-end, while docker-compose.yml orchestrates container deployment with persistent storage for uploaded files and database data.

Key Changes:
Dockerfile: Multi-stage build for Node.js and Go applications.
docker-compose.yml: Manages service orchestration and persistence.

Instructions:
Start the application:
docker-compose up -d

Please review and provide feedback.