### PR TITLE
fix: replace 'arch' command with 'uname -m' for cross-platform compat…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BINARY_NAME=go-fast-cdn
 OS_NAME := $(shell uname -s | tr A-Z a-z)
-ARCH := $(shell arch | tr A-Z a-z | sed 's/^aarch/arm/')
+ARCH := $(shell uname -m | tr A-Z a-z | sed 's/^aarch/arm/')
 
 prep:
 	go mod tidy


### PR DESCRIPTION
This PR updates the ARCH variable assignment in the Makefile to use uname -m instead of arch. The arch command may not be available on all systems, which can lead to compatibility issues, while uname -m is part of the POSIX standard and more widely supported across Unix-like operating systems. 