### PR TITLE
 Add Air for live reload

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,52 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./tmp/main"
+  cmd = "go build -o ./tmp/main ."
+  delay = 1000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html"]
+  include_file = []
+  kill_delay = "0s"
+  log = "build-errors.log"
+  poll = false
+  poll_interval = 0
+  post_cmd = []
+  pre_cmd = []
+  rerun = false
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_error = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  silent = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[proxy]
+  app_port = 0
+  enabled = false
+  proxy_port = 0
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ prep:
 	go mod tidy
 	go mod download
 	cd ui && pnpm i
+	go install github.com/air-verse/air@latest
 
 build: build_ui build_bin
 
@@ -23,6 +24,9 @@ ifeq ($(OS_NAME),)
 else
 	bin/${BINARY_NAME}-${OS_NAME}
 endif
+
+dev:
+	air
 
 clean: 
 	go clean

--- a/docs/src/content/docs/contribution/development.md
+++ b/docs/src/content/docs/contribution/development.md
@@ -39,6 +39,8 @@ go build .
 
 ### Running
 
+#### Running the binary
+
 Your binary should now be built and you can run it with one of the following commands, depending on your system:
 
 ```sh title="Windows"
@@ -52,3 +54,14 @@ Your binary should now be built and you can run it with one of the following com
 ```bash title="Linux"
 /bin/go-fast-cdn-linux
 ```
+
+#### Running with live reload
+
+For faster development cycles, you can also run the project with [air](https://github.com/air-verse/air).
+
+```bash
+make prep  # if you haven't already
+make dev   # runs with live reload
+```
+
+Now try and make changes to the code, and immediately see it reflected in the browser.

--- a/docs/src/content/docs/es/contribution/development.md
+++ b/docs/src/content/docs/es/contribution/development.md
@@ -40,6 +40,8 @@ go build .
 
 ### Ejecución
 
+#### Ejecutando el binario
+
 Tu binario debería estar construido ahora y puedes ejecutarlo con uno de los siguientes comandos, dependiendo de tu sistema:
 
 ```sh title="Windows"
@@ -53,3 +55,14 @@ Tu binario debería estar construido ahora y puedes ejecutarlo con uno de los si
 ```bash title="Linux"
 /bin/go-fast-cdn-linux
 ```
+
+#### Ejecutando con recarga en vivo
+
+Para ciclos de desarrollo más rápidos, también puedes ejecutar el proyecto con [air](https://github.com/air-verse/air).
+
+```bash
+make prep  # si aún no lo has hecho
+make dev   # ejecuta con recarga en vivo
+```
+
+Ahora intenta hacer cambios en el código y verlos reflejados inmediatamente en el navegador.


### PR DESCRIPTION
This is a pretty simple PR to add support for the [air](https://github.com/air-verse/air) tool.

It can be merged right away, but I ask that most of it gets carefully reviewed, for the following reasons:

It's using the default `.air.toml` config file, which simply just works, but I'm not familiar enough with the repo to know of any edge cases that could've been overlooked.

I decided to keep the original `make run` command, in case any users rely on it for deployment. A new command, `make dev`, has been added instead.

I also updated the docs accordingly, but since we now have two ways of running the tool, I've split the `Running` section into two subsections. This causes the page's header level to be 4 deep, which is ok afaict, but I could find another way of formatting it if necessary. Also, Spanish is not my strong point, so validation from a Spanish-speaking dev on the Spanish docs will be much appreciated.

I've noticed that despite the repo having the `make run` command, the docs do not mention it anywhere. Instead, they instruct users to directly run the binary based on their architecture/OS. I didn't touch that, but if the change is welcome, I can include it here or in another PR.

Thanks in advance.

Closes #113 