### PR TITLE
docs: fix invalid git clone URL across documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See our documentation at [kevinanielsen.github.io/go-fast-cdn/](https://kevinani
 ### Clone the Repository
 
 `git clone git@github.com:kevinanielsen/go-fast-cdn`
-or `git clone https://github.com:kevinanielsen/go-fast-cdn`
+or `git clone https://github.com/kevinanielsen/go-fast-cdn`
 
 ### Add env variables
 
@@ -47,7 +47,7 @@ Your binary should now be tested, built, and you can run it with `bin/go-fast-cd
 ### Quick start with Docker
 
 `git clone git@github.com:kevinanielsen/go-fast-cdn`
-or `git clone https://github.com:kevinanielsen/go-fast-cdn`
+or `git clone https://github.com/kevinanielsen/go-fast-cdn`
 
 ```
 docker-compose up -d

--- a/docs/src/content/docs/contribution/development.md
+++ b/docs/src/content/docs/contribution/development.md
@@ -14,7 +14,7 @@ git clone git@github.com:kevinanielsen/go-fast-cdn
 ```
 
 ```bash title="HTTPS"
-git clone https://github.com:kevinanielsen/go-fast-cdn
+git clone https://github.com/kevinanielsen/go-fast-cdn
 ```
 
 ### Setting up the project

--- a/docs/src/content/docs/es/contribution/development.md
+++ b/docs/src/content/docs/es/contribution/development.md
@@ -14,7 +14,7 @@ git clone git@github.com:kevinanielsen/go-fast-cdn
 ```
 
 ```bash title="HTTPS"
-git clone https://github.com:kevinanielsen/go-fast-cdn
+git clone https://github.com/kevinanielsen/go-fast-cdn
 ```
 
 ### Configurando el proyecto


### PR DESCRIPTION
This PR fixes an incorrect git clone URL used in documentation. The previous URL:
```git clone https://github.com:kevinanielsen/go-fast-cdn```
is invalid for HTTP because of the colon between the host and the path. It's interpreted as a port and fails.

All instances have been replaced with  `git clone https://github.com/kevinanielsen/go-fast-cdn`. (replace colon with slash)

No code changes just a typo fix.
