### PR TITLE
feat: log error when web server fails to start

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"log"
-	"os"
-
 	"github.com/gin-gonic/gin"
 	"github.com/kevinanielsen/go-fast-cdn/src/database"
 	ini "github.com/kevinanielsen/go-fast-cdn/src/initializers"
@@ -21,6 +18,5 @@ func init() {
 }
 
 func main() {
-	log.Printf("Starting server on port %v", os.Getenv("PORT"))
 	router.Router()
 }

--- a/src/router/router.go
+++ b/src/router/router.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"log"
 	"os"
 
 	"github.com/kevinanielsen/go-fast-cdn/src/middleware"
@@ -23,5 +24,6 @@ func Router() {
 	// Add the embedded ui routes
 	ui.AddRoutes(s.Engine)
 
-	s.Run()
+	log.Printf("Starting server on port %v", port)
+	log.Fatal(s.Run())
 }

--- a/src/router/server.go
+++ b/src/router/server.go
@@ -32,6 +32,7 @@ func WithMiddleware(middleware gin.HandlerFunc) func(*Server) {
 	}
 }
 
-func (s *Server) Run() {
-	s.Engine.Run(s.Port)
+func (s *Server) Run() error {
+	err := s.Engine.Run(s.Port)
+	return err
 }


### PR DESCRIPTION
Fixes #198

## Description
Logs a fatal error message when the web server fails to start.

## Scenario
The most common scenario is when the web port is already in use by another application.

### Before
The program would exit silently without any error prompt or explanation.
```console
➜  go-fast-cdn git:(main) ✗ go run main.go 
2025/11/21 22:52:23 DB not found, creating at /tmp/go-build886842778/b001/exe/db_data/main.db...
2025/11/21 22:52:23 Connected to database!
2025/11/21 22:52:23 Database initialized!
2025/11/21 22:52:23 Starting server on port 8080
```
### After
The program now displays the specific error reason before exiting.
```console
➜  go-fast-cdn git:(log-on-start) ✗ go run main.go 
2025/11/30 22:23:01 DB not found, creating at /tmp/go-build129749068/b001/exe/db_data/main.db...
2025/11/30 22:23:01 Connected to database!
2025/11/30 22:23:01 Database initialized!
2025/11/30 22:23:01 Starting server on port :8080
2025/11/30 22:23:01 listen tcp :8080: bind: address already in use
exit status 1
```