### PR TITLE
fix: replace deprecated archives.format with formats

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -112,7 +112,8 @@ archives:
     builds:
       - linux-amd64
     name_template: "{{ .ProjectName }}_{{ .Version }}_linux_amd64"
-    format: zip
+    formats:
+      - zip
     files:
       - LICENSE*
       - README*
@@ -121,7 +122,8 @@ archives:
     builds:
       - linux-arm64
     name_template: "{{ .ProjectName }}_{{ .Version }}_linux_arm64"
-    format: zip
+    formats:
+      - zip
     files:
       - LICENSE*
       - README*
@@ -130,7 +132,8 @@ archives:
     builds:
       - linux-armv7
     name_template: "{{ .ProjectName }}_{{ .Version }}_linux_armv7"
-    format: zip
+    formats:
+      - zip
     files:
       - LICENSE*
       - README*
@@ -139,7 +142,8 @@ archives:
     builds:
       - darwin-amd64
     name_template: "{{ .ProjectName }}_{{ .Version }}_darwin_amd64"
-    format: zip
+    formats:
+      - zip
     files:
       - LICENSE*
       - README*
@@ -148,7 +152,8 @@ archives:
     builds:
       - darwin-arm64
     name_template: "{{ .ProjectName }}_{{ .Version }}_darwin_arm64"
-    format: zip
+    formats:
+      - zip
     files:
       - LICENSE*
       - README*
@@ -157,7 +162,8 @@ archives:
     builds:
       - windows-amd64
     name_template: "{{ .ProjectName }}_{{ .Version }}_windows_amd64"
-    format: zip
+    formats:
+      - zip
     files:
       - LICENSE*
       - README*


### PR DESCRIPTION
## Summary

Updates GoReleaser configuration to replace the deprecated `archives.format` field with `archives.formats`.

This removes the warning in the release workflow:

> DEPRECATED: archives.format should not be used anymore

No functional changes to the release artifacts.

Closes #232.